### PR TITLE
fix: ensure dirs arent empty strings

### DIFF
--- a/functions/_tide_parent_dirs.fish
+++ b/functions/_tide_parent_dirs.fish
@@ -1,7 +1,11 @@
 function _tide_parent_dirs --on-variable PWD
-    set -g _tide_parent_dirs (string escape (
-        for dir in (string split / -- $PWD)
-            set -la parts $dir
-            string join / -- $parts
-        end))
+    set -g _tide_parent_dirs (
+        string escape (
+            for dir in (string split / -- $PWD)
+                if test (string length \"$dir\") -lt 1
+                    continue
+                end
+                set -a parts $dir
+                string join "" (string join / --  $parts) ""
+            end))
 end


### PR DESCRIPTION
This fixes issue 564 also safely wraps strings for parsing

[564]

<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
